### PR TITLE
Fixed leaking formatBlockSelectItem variable.

### DIFF
--- a/ux/form/plugin/HtmlEditor.js
+++ b/ux/form/plugin/HtmlEditor.js
@@ -194,7 +194,7 @@ Ext.define('Ext.ux.form.plugin.HtmlEditor', {
                     caption:    me.buttonTips.listFormatBlocks[me.listFormatBlocks[i]]
                 });
             }
-            formatBlockSelectItem = Ext.widget('component', {
+            var formatBlockSelectItem = Ext.widget('component', {
                 renderTpl: [
                     '<select class="{cls}">',
                         '<tpl for="formats">',


### PR DESCRIPTION
Variable formatBlockSelectItem (select input field) was leaked and if variable is set by first html editor (with enableFormatBlocks=True), then second html editor (with enableFormatBlocks=False) in the same page attach it self to this select input. Then select input change is proped to both editors